### PR TITLE
Using project.configurations.create instead of project.configurations.add

### DIFF
--- a/src/main/groovy/org/github/mansur/scalastyle/ScalaStylePlugin.groovy
+++ b/src/main/groovy/org/github/mansur/scalastyle/ScalaStylePlugin.groovy
@@ -30,7 +30,7 @@ class ScalaStylePlugin implements Plugin<Project> {
 
 
     void apply(Project project) {
-        project.configurations.add("scalaStyle")
+        project.configurations.create("scalaStyle")
                 .setVisible(false)
                 .setTransitive(true)
                 .setDescription('Scala Style libraries to be used for this project.')


### PR DESCRIPTION
Pull requires to avoid the following warning when using the ScalaStyle plugin with Gradle version >= 1.6:
`The ConfigurationContainer.add() method has been deprecated and is scheduled to be removed in Gradle 2.0. Please use the create() method instead.`
- http://www.gradle.org/docs/1.6/release-notes#renamed-several-add()-methods
